### PR TITLE
Add new tempest jobs and replace old one

### DIFF
--- a/tripleoci/config.py
+++ b/tripleoci/config.py
@@ -44,7 +44,10 @@ PERIODIC_URLS = [
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-ovb-fakeha-caserver',
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-ovb-ha-newton',
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-ovb-ha-ocata',
-    PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq',
+    PERIODIC_LOGS_URL +
+    '/periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq-ocata',
+    PERIODIC_LOGS_URL +
+    '/periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq-master',
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-scenario001-multinode',
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-scenario002-multinode',
     PERIODIC_LOGS_URL + '/periodic-tripleo-ci-centos-7-scenario003-multinode',


### PR DESCRIPTION
periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq job was renamed
to periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq-master and
a new job running in ocata stable branch was created with the name
periodic-tripleo-ci-centos-7-ovb-nonha-tempest-oooq-ocata.