### PR TITLE
update sova urls

### DIFF
--- a/html/template.html
+++ b/html/template.html
@@ -38,7 +38,7 @@
 
 <div class="page-header" align="center">
     <h3>
-        <a href="http://cistatus.tripleo.org/">TripleO CI check jobs</a>
+        <a href="http://cistatus.tripleo.org">TripleO CI check jobs</a>
     </h3>
     <h3>
         <a href="http://cistatus.tripleo.org/gates/">TripleO CI gate jobs</a>

--- a/html/template.html
+++ b/html/template.html
@@ -38,19 +38,19 @@
 
 <div class="page-header" align="center">
     <h3>
-        <a href="http://cistatus.tripleo.org">TripleO CI check jobs</a>
+        <a href="http://cistatus.tripleo.org/gates/">TripleO CI gate jobs</a>
     </h3>
     <h3>
-        <a href="http://cistatus.tripleo.org:8000">TripleO CI gate jobs</a>
+        <a href="http://cistatus.tripleo.org/promotion/">TripleO CI promotion jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.35.214/">TripleO CI promotion jobs</a>
+        <a href="http://cistatus.tripleo.org/promotion/">TripleO CI upgrades jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.35.214/">TripleO CI upgrades jobs</a>
+        <a href="http://cistatus.tripleo.org/phase1/">RDO CI phase1 promotion jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.35.194/">RDO CI phase2 promotion jobs</a>
+        <a href="http://cistatus.tripleo.org/phase2/ ">RDO CI phase2 promotion jobs</a>
     </h3>
     <br>
     <h2><u>

--- a/html/template.html
+++ b/html/template.html
@@ -38,6 +38,9 @@
 
 <div class="page-header" align="center">
     <h3>
+        <a href="http://cistatus.tripleo.org/">TripleO CI check jobs</a>
+    </h3>
+    <h3>
         <a href="http://cistatus.tripleo.org/gates/">TripleO CI gate jobs</a>
     </h3>
     <h3>


### PR DESCRIPTION
Sova urls have been updated to use

main instance: http://cistatus.tripleo.org/
promotion and rdo cloud jobs: http://cistatus.tripleo.org/promotion/
gate jobs: http://cistatus.tripleo.org/gates/
ci.centos jobs:  http://cistatus.tripleo.org/phase1/