### PR TITLE
update sova urls

### DIFF
--- a/html/template.html
+++ b/html/template.html
@@ -41,13 +41,16 @@
         <a href="http://cistatus.tripleo.org/">TripleO CI check jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.34.234/">TripleO CI promotion jobs</a>
+        <a href="http://cistatus.tripleo.org/promotion/">TripleO CI promotion jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.34.234/">TripleO CI upgrades jobs</a>
+        <a href="http://cistatus.tripleo.org/promotion/">TripleO CI upgrades jobs</a>
     </h3>
     <h3>
-        <a href="http://38.145.33.245/">RDO CI phase1 promotion jobs</a>
+        <a href="http://cistatus.tripleo.org/phase1/">RDO CI phase1 promotion jobs</a>
+    </h3>
+    <h3>
+        <a href="http://cistatus.tripleo.org/phase2/ ">RDO CI phase2 promotion jobs</a>
     </h3>
     <br>
     <h2><u>


### PR DESCRIPTION
Sova urls have been updated to use

main instance: http://cistatus.tripleo.org/
promotion and rdo cloud jobs: http://cistatus.tripleo.org/promotion/
gate jobs: http://cistatus.tripleo.org/gates/
ci.centos jobs:  http://cistatus.tripleo.org/phase1/