### PR TITLE
Replace RDO legacy jobs with converted zuulv3 jobs

### DIFF
--- a/tripleoci/config.py
+++ b/tripleoci/config.py
@@ -154,54 +154,54 @@ COLUMNED_TRACKED_JOBS = {
 
     ],
     "OVB": [
-        'legacy-tripleo-ci-centos-7-ovb-1ctlr_1comp_1ceph-featureset024-ocata',
-        'legacy-tripleo-ci-centos-7-ovb-1ctlr_1comp_1ceph-featureset024-pike',
-        'legacy-tripleo-ci-centos-7-ovb-1ctlr_1comp-featureset020-master',
-        'legacy-tripleo-ci-centos-7-ovb-1ctlr_1comp-featureset022-pike',
-        ('legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp_1supp-featureset039-'
+        'tripleo-ci-centos-7-ovb-1ctlr_1comp_1ceph-featureset024-ocata',
+        'tripleo-ci-centos-7-ovb-1ctlr_1comp_1ceph-featureset024-pike',
+        'tripleo-ci-centos-7-ovb-1ctlr_1comp-featureset020-master',
+        'tripleo-ci-centos-7-ovb-1ctlr_1comp-featureset022-pike',
+        ('tripleo-ci-centos-7-ovb-3ctlr_1comp_1supp-featureset039-'
          'master'),
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-master',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-ocata',
-        ('legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-ocata-'
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-master',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-ocata',
+        ('tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-ocata-'
          'branch'),
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-pike',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-pike-branch',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-queens',
-        ('legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-queens-'
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-pike',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-pike-branch',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-queens',
+        ('tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-queens-'
          'branch'),
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-rocky',
-        ('legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-rocky-'
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-rocky',
+        ('tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset001-rocky-'
          'branch'),
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-master',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-ocata',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-pike',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-queens',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-master',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-queens',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-rocky',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-master',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-master-tht',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-queens',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-queens-tht',
-        'legacy-tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset053-master',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-master',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-ocata',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-pike',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset021-queens',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-master',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-queens',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset035-rocky',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-master',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-master-tht',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-queens',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset042-queens-tht',
+        'tripleo-ci-centos-7-ovb-3ctlr_1comp-featureset053-master',
     ],
     "RDO cloud multinode": [
-        'legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset016-master',
-        'legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset017-master',
-        'legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset018-master',
-        'legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset019-master',
-        ('legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset036-oc-ffu-'
+        'tripleo-ci-centos-7-multinode-1ctlr-featureset016-master',
+        'tripleo-ci-centos-7-multinode-1ctlr-featureset017-master',
+        'tripleo-ci-centos-7-multinode-1ctlr-featureset018-master',
+        'tripleo-ci-centos-7-multinode-1ctlr-featureset019-master',
+        ('tripleo-ci-centos-7-multinode-1ctlr-featureset036-oc-ffu-'
          'queens'),
-        ('legacy-tripleo-ci-centos-7-multinode-1ctlr-featureset037-updates-'
+        ('tripleo-ci-centos-7-multinode-1ctlr-featureset037-updates-'
          'master'),
     ],
     "RDO cloud upgrades": [
-        'legacy-tripleo-ci-centos-7-containers-multinode-upgrades-pike',
-        'legacy-tripleo-ci-centos-7-containers-multinode-upgrades-pike-branch',
-        ('legacy-tripleo-ci-centos-7-container-to-container-featureset051-'
+        'tripleo-ci-centos-7-containers-multinode-upgrades-pike',
+        'tripleo-ci-centos-7-containers-multinode-upgrades-pike-branch',
+        ('tripleo-ci-centos-7-container-to-container-featureset051-'
          'upgrades-master'),
-        'legacy-tripleo-ci-centos-7-container-to-container-upgrades-master',
-        'legacy-tripleo-ci-centos-7-container-to-container-upgrades-queens',
+        'tripleo-ci-centos-7-container-to-container-upgrades-master',
+        'tripleo-ci-centos-7-container-to-container-upgrades-queens',
     ]
 }
 TRIPLEOCI = {


### PR DESCRIPTION
We need to track the new zuul v3 based jobs that run in RDO