### PR TITLE
Add scen007 standalone job to the status page

### DIFF
--- a/tripleoci/config.py
+++ b/tripleoci/config.py
@@ -120,6 +120,7 @@ COLUMNED_TRACKED_JOBS = {
         "tripleo-ci-centos-7-scenario002-standalone",
         "tripleo-ci-centos-7-scenario003-standalone",
         "tripleo-ci-centos-7-scenario004-standalone",
+        "tripleo-ci-centos-7-scenario007-standalone",
         "tripleo-ci-centos-7-scenario012-standalone",
         "tripleo-ci-centos-7-scenario010-standalone",
         "tripleo-ci-centos-7-standalone-os-tempest",


### PR DESCRIPTION
tripleo-ci-centos-7-scenario007-standalone has been running
for a while in upstream zuul and deserves a seat on the table.

http://zuul.openstack.org/builds?job_name=tripleo-ci-centos-7-scenario007-standalone#

Story: https://tree.taiga.io/project/tripleo-ci-board/us/341