### PR TITLE
Phase 1 of the log move

### DIFF
--- a/tripleoci/patches.py
+++ b/tripleoci/patches.py
@@ -9,7 +9,7 @@ from tripleoci.utils import Web
 
 ZUUL_STATUSES = ["SUCCESS", "FAILURE", "RETRY_LIMIT", "POST_FAILURE",
                  "TIMED_OUT"]
-JOB_RE = re.compile(r"(\S+) (http://logs.openstack.org/\S+) "
+JOB_RE = re.compile(r"(\S+) (http://logs.opendev.org/\S+) "
                     r": (%s) in ([hms \d]+)" % "|".join(ZUUL_STATUSES))
 JOB_RE2 = re.compile(r"(\S+) (https://review.rdoproject.org/\S+) "
                      r": (%s) in ([hms \d]+)" % "|".join(ZUUL_STATUSES))


### PR DESCRIPTION
Upstream logs will be sent to logs.opendev.org.
The log links will go to the build page now - however the log server for the short time is static at  logs.opendev.org.

DO NOT MERGE w/o sshnaidm review